### PR TITLE
Feature/transfer_commission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts
 .idea
 packages/*/schema
 contracts/*/schema
+**/.DS_Store

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -74,9 +74,9 @@ pub fn execute(
     match msg {
         ExecuteMsg::UpdateConfig {
             owner,
-            team_commision,
+            team_commission,
             unbonding_period,
-        } => execute::update_config(deps, info, owner, team_commision, unbonding_period),
+        } => execute::update_config(deps, info, owner, team_commission, unbonding_period),
         ExecuteMsg::UpdateValidatorList { new_validator_list } => {
             execute::update_validator_list(deps, info, new_validator_list)
         }
@@ -120,8 +120,8 @@ mod execute {
             config.owner = owner;
         }
 
-        if let Some(team_commision) = new_team_commision {
-            config.team_commision = team_commision;
+        if let Some(team_commission) = new_team_commission {
+            config.team_commission = team_commission;
         }
 
         if let Some(unbonding_period) = new_unbonding_period {
@@ -410,7 +410,7 @@ mod execute {
             .add_attribute("action", "restake")
             .add_attribute("amount", reward.amount)
             .add_messages(reward_msgs)
-            .add_messages(commision_msgs)
+            .add_messages(commission_msgs)
             .add_messages(delegate_msgs))
     }
 

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -103,6 +103,8 @@ pub fn execute(
 
 mod execute {
 
+    use cosmwasm_std::Fraction;
+
     use crate::state::VALIDATOR_LIST;
 
     use super::{
@@ -438,16 +440,17 @@ mod execute {
         amount: Uint128,
     ) -> Result<Response, ContractError> {
         let recipient = deps.api.addr_validate(&recipient)?;
-        let denom = CONFIG.load(deps.as_ref().storage)?.denom;
+        let config = CONFIG.load(deps.as_ref().storage)?;
 
         STAKE_DETAILS.update(deps.storage, &sender, |stake_details| -> StdResult<_> {
             let mut stake_details =
-                unwrap_stake_details(stake_details, denom.clone(), env.block.height);
+                unwrap_stake_details(stake_details, config.denom.clone(), env.block.height);
             stake_details.total.amount = stake_details.total.amount.checked_sub(amount)?;
             Ok(stake_details)
         })?;
         STAKE_DETAILS.update(deps.storage, &recipient, |stake_details| -> StdResult<_> {
-            let mut stake_details = unwrap_stake_details(stake_details, denom, env.block.height);
+            let mut stake_details =
+                unwrap_stake_details(stake_details, config.denom.clone(), env.block.height);
             stake_details.total.amount = stake_details.total.amount.checked_add(amount)?;
             Ok(stake_details)
         })?;

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -9,6 +9,8 @@ use cw2::set_contract_version;
 use cw_utils::ensure_from_older_version;
 
 use crate::error::ContractError;
+
+use crate::migration::migrate_config;
 use crate::msg::{
     ClaimsResponse, ConfigResponse, DelegateResponse, DelegatedResponse, ExecuteMsg,
     InstantiateMsg, LastPaymentBlockResponse, MigrateMsg, QueryMsg, RewardResponse,
@@ -45,7 +47,7 @@ pub fn instantiate(
     let config = Config {
         owner: owner.clone(),
         treasury,
-        team_commission,
+        team_commission: msg.team_commission,
         denom: msg.denom.clone(),
         unbonding_period,
     };
@@ -120,7 +122,7 @@ mod execute {
         info: MessageInfo,
         new_owner: Option<String>,
         treasury: Option<String>,
-        new_team_commission: Option<TeamCommission>,
+        new_team_commission: Option<Decimal>,
         new_unbonding_period: Option<u64>,
     ) -> Result<Response, ContractError> {
         let mut config = CONFIG.load(deps.storage)?;

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -489,6 +489,10 @@ mod execute {
             // split the commission 50/50 between the commission address and the treasury
             if let Some(commission_address) = commission_address.clone() {
                 let commission_address = deps.api.addr_validate(&commission_address)?;
+                if recipient == commission_address {
+                    return Err(ContractError::CommissionAddressSameAsRecipient {});
+                }
+
                 let expiration = ALLOWED_ADDRESSES.may_load(deps.storage, &commission_address)?;
 
                 // check if the commission address is allowed

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -125,7 +125,7 @@ pub fn execute(
 
 mod execute {
 
-    use cosmwasm_std::Fraction;
+    
     use cw_utils::Expiration;
 
     use crate::state::{ALLOWED_ADDRESSES, VALIDATOR_LIST};
@@ -694,7 +694,7 @@ mod execute {
 
     pub fn remove_allowed_address(
         deps: DepsMut,
-        env: Env,
+        _env: Env,
         info: MessageInfo,
         address: String,
     ) -> Result<Response, ContractError> {

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -118,7 +118,7 @@ pub fn execute(
             execute::update_allowed_address(deps, env, info, address, expires)
         }
         ExecuteMsg::RemoveAllowedAddr { address } => {
-            execute::remove_allowed_address(deps, env, info, address)
+            execute::remove_allowed_address(deps, info, address)
         }
     }
 }
@@ -709,7 +709,6 @@ mod execute {
 
     pub fn remove_allowed_address(
         deps: DepsMut,
-        _env: Env,
         info: MessageInfo,
         address: String,
     ) -> Result<Response, ContractError> {

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -125,7 +125,6 @@ pub fn execute(
 
 mod execute {
 
-    
     use cw_utils::Expiration;
 
     use crate::state::{ALLOWED_ADDRESSES, VALIDATOR_LIST};

--- a/contracts/interstake-yield-generator/src/error.rs
+++ b/contracts/interstake-yield-generator/src/error.rs
@@ -39,7 +39,7 @@ pub enum ContractError {
     #[error("Expiration must be at least a month from now")]
     ExpirationTooSoon {},
 
-    #[error("Address {address} not found in allowd list of commissions")]
+    #[error("Address {address} not found in allowed list of commissions")]
     CommissionAddressNotFound { address: String },
 
     #[error("Allowance of Commission Address {address} is expired")]

--- a/contracts/interstake-yield-generator/src/error.rs
+++ b/contracts/interstake-yield-generator/src/error.rs
@@ -39,6 +39,9 @@ pub enum ContractError {
     #[error("Expiration must be at least a month from now")]
     ExpirationTooSoon {},
 
-    #[error("Allowed Address not found")]
-    AllowedAddressNotFound {},
+    #[error("Address {address} not found in allowd list of commissions")]
+    CommissionAddressNotFound { address: String },
+
+    #[error("Allowance of Commission Address {address} is expired")]
+    CommissionAddressExpired { address: String },
 }

--- a/contracts/interstake-yield-generator/src/error.rs
+++ b/contracts/interstake-yield-generator/src/error.rs
@@ -35,4 +35,10 @@ pub enum ContractError {
 
     #[error("Delegation not found")]
     DelegationNotFound {},
+
+    #[error("Expiration must be at least a month from now")]
+    ExpirationTooSoon {},
+
+    #[error("Allowed Address not found")]
+    AllowedAddressNotFound {},
 }

--- a/contracts/interstake-yield-generator/src/error.rs
+++ b/contracts/interstake-yield-generator/src/error.rs
@@ -44,4 +44,7 @@ pub enum ContractError {
 
     #[error("Allowance of Commission Address {address} is expired")]
     CommissionAddressExpired { address: String },
+
+    #[error("Commission address may not be the same as the recipient")]
+    CommissionAddressSameAsRecipient {},
 }

--- a/contracts/interstake-yield-generator/src/lib.rs
+++ b/contracts/interstake-yield-generator/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 mod error;
+mod migration;
 pub mod msg;
 #[cfg(test)]
 mod multitest;

--- a/contracts/interstake-yield-generator/src/migration.rs
+++ b/contracts/interstake-yield-generator/src/migration.rs
@@ -31,7 +31,8 @@ pub fn migrate_config(
         let new_config = Config {
             owner: config.owner,
             treasury,
-            team_commission: config.team_commission,
+            restake_commission: config.team_commission,
+            transfer_commission: msg.transfer_commission,
             denom: config.denom,
             unbonding_period: Timestamp::from_seconds(3600 * 24 * 28), // default 28 days
         };

--- a/contracts/interstake-yield-generator/src/migration.rs
+++ b/contracts/interstake-yield-generator/src/migration.rs
@@ -1,0 +1,34 @@
+use schemars::JsonSchema;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Addr, DepsMut, Timestamp};
+use cw_storage_plus::Item;
+
+use crate::error::ContractError;
+use crate::state::{Config, TeamCommission, CONFIG};
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ConfigV0_1_5 {
+    pub owner: Addr,
+    // pub staking_addr: String, // this field is removed in 0.1.5
+    pub team_commission: TeamCommission,
+    pub denom: String,
+}
+
+pub fn migrate_config(deps: DepsMut, version: &Version) -> Result<(), ContractError> {
+    if *version < "0.1.4".parse::<Version>().unwrap() {
+        let old_storage: Item<ConfigV0_1_5> = Item::new("config");
+        let config = old_storage.load(deps.storage)?;
+
+        let new_config = Config {
+            owner: config.owner,
+            team_commission: config.team_commission,
+            denom: config.denom,
+            unbonding_period: Timestamp::from_seconds(3600 * 24 * 28), // default 28 days
+        };
+        CONFIG.save(deps.storage, &new_config)?
+    }
+    Ok(())
+}

--- a/contracts/interstake-yield-generator/src/migration.rs
+++ b/contracts/interstake-yield-generator/src/migration.rs
@@ -6,6 +6,7 @@ use cosmwasm_std::{Addr, DepsMut, Timestamp};
 use cw_storage_plus::Item;
 
 use crate::error::ContractError;
+use crate::msg::MigrateMsg;
 use crate::state::{Config, TeamCommission, CONFIG};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
@@ -17,13 +18,19 @@ pub struct ConfigV0_1_5 {
     pub denom: String,
 }
 
-pub fn migrate_config(deps: DepsMut, version: &Version) -> Result<(), ContractError> {
+pub fn migrate_config(
+    deps: DepsMut,
+    version: &Version,
+    msg: MigrateMsg,
+) -> Result<(), ContractError> {
     if *version < "0.1.4".parse::<Version>().unwrap() {
         let old_storage: Item<ConfigV0_1_5> = Item::new("config");
         let config = old_storage.load(deps.storage)?;
 
+        let treasury = deps.api.addr_validate(msg.treasury.as_str())?;
         let new_config = Config {
             owner: config.owner,
+            treasury,
             team_commission: config.team_commission,
             denom: config.denom,
             unbonding_period: Timestamp::from_seconds(3600 * 24 * 28), // default 28 days

--- a/contracts/interstake-yield-generator/src/migration.rs
+++ b/contracts/interstake-yield-generator/src/migration.rs
@@ -2,19 +2,19 @@ use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, DepsMut, Timestamp};
+use cosmwasm_std::{Addr, Decimal, DepsMut, Timestamp};
 use cw_storage_plus::Item;
 
 use crate::error::ContractError;
 use crate::msg::MigrateMsg;
-use crate::state::{Config, TeamCommission, CONFIG};
+use crate::state::{Config, CONFIG};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ConfigV0_1_5 {
     pub owner: Addr,
     // pub staking_addr: String, // this field is removed in 0.1.5
-    pub team_commission: TeamCommission,
+    pub team_commission: Decimal,
     pub denom: String,
 }
 

--- a/contracts/interstake-yield-generator/src/msg.rs
+++ b/contracts/interstake-yield-generator/src/msg.rs
@@ -25,7 +25,7 @@ pub enum ExecuteMsg {
     UpdateConfig {
         owner: Option<String>,
         treasury: Option<String>,
-        team_commision: Option<Decimal>,
+        team_commission: Option<Decimal>,
         unbonding_period: Option<u64>,
     },
     /// Updates the list of validators that will be used for staking

--- a/contracts/interstake-yield-generator/src/msg.rs
+++ b/contracts/interstake-yield-generator/src/msg.rs
@@ -56,7 +56,7 @@ pub enum ExecuteMsg {
     UpdateAllowedAddr {
         address: String,
         /// seconds since epoch
-        expires: Option<u64>,
+        expires: u64,
     },
     /// removes address from allowed list
     RemoveAllowedAddr { address: String },

--- a/contracts/interstake-yield-generator/src/msg.rs
+++ b/contracts/interstake-yield-generator/src/msg.rs
@@ -7,10 +7,12 @@ use crate::state::{ClaimDetails, Config};
 pub struct InstantiateMsg {
     /// Multisig contract that is allowed to perform admin operations
     pub owner: String,
+    /// account which receives commissions
+    pub treasury: String,
     /// Address of validator
     pub staking_addr: String,
     /// Commission of Intrastake team
-    pub team_commision: Decimal,
+    pub team_commission: Decimal,
     /// Used denom
     pub denom: String,
     /// Unbondig period in seconds. Default: 2_419_200 (28 days)
@@ -22,6 +24,7 @@ pub enum ExecuteMsg {
     /// Only called by owner
     UpdateConfig {
         owner: Option<String>,
+        treasury: Option<String>,
         team_commision: Option<Decimal>,
         unbonding_period: Option<u64>,
     },
@@ -71,7 +74,9 @@ pub enum QueryMsg {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub treasury: String,
+}
 
 #[cw_serde]
 pub struct ConfigResponse {

--- a/contracts/interstake-yield-generator/src/multitest/config.rs
+++ b/contracts/interstake-yield-generator/src/multitest/config.rs
@@ -12,7 +12,7 @@ fn update_not_owner() {
     let mut suite = SuiteBuilder::new().build();
 
     let err = suite
-        .update_config("random_user", None, None, None, None)
+        .update_config("random_user", None, None, None, None, None)
         .unwrap_err();
     assert_eq!(ContractError::Unauthorized {}, err.downcast().unwrap());
 }
@@ -28,21 +28,23 @@ fn proper_update() {
         Config {
             owner: owner.clone(),
             treasury: treasury.clone(),
-            team_commission: Decimal::zero(),
+            restake_commission: Decimal::zero(),
+            transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
         }
     );
 
     suite
-        .update_config(owner.as_str(), None, None, None, None)
+        .update_config(owner.as_str(), None, None, None, None, None)
         .unwrap();
     assert_eq!(
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
             treasury: treasury.clone(),
-            team_commission: Decimal::zero(),
+            restake_commission: Decimal::zero(),
+            transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
         }
@@ -56,6 +58,7 @@ fn proper_update() {
             None,
             new_team_commission.clone(),
             None,
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -63,7 +66,8 @@ fn proper_update() {
         Config {
             owner: owner.clone(),
             treasury: treasury.clone(),
-            team_commission: new_team_commission.clone(),
+            restake_commission: new_team_commission.clone(),
+            transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
         }
@@ -71,14 +75,15 @@ fn proper_update() {
 
     let new_unbonding_period = 300_000_000u64;
     suite
-        .update_config(owner.as_str(), None, None, None, new_unbonding_period)
+        .update_config(owner.as_str(), None, None, None, None, new_unbonding_period)
         .unwrap();
     assert_eq!(
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
             treasury: treasury.clone(),
-            team_commission: new_team_commission.clone(),
+            restake_commission: new_team_commission.clone(),
+            transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(new_unbonding_period),
         }
@@ -86,14 +91,38 @@ fn proper_update() {
 
     let new_treasury = "new_treasury".to_owned();
     suite
-        .update_config(owner.as_str(), None, new_treasury.clone(), None, None)
+        .update_config(owner.as_str(), None, new_treasury.clone(), None, None, None)
         .unwrap();
     assert_eq!(
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
             treasury: Addr::unchecked(new_treasury.clone()),
-            team_commission: new_team_commission.clone(),
+            restake_commission: new_team_commission.clone(),
+            transfer_commission: Decimal::zero(),
+            denom: "ujuno".to_owned(),
+            unbonding_period: Timestamp::from_seconds(new_unbonding_period),
+        }
+    );
+
+    let new_transfer_commission = Decimal::percent(5);
+    suite
+        .update_config(
+            owner.as_str(),
+            None,
+            None,
+            None,
+            new_transfer_commission.clone(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        suite.query_config().unwrap(),
+        Config {
+            owner: owner.clone(),
+            treasury: Addr::unchecked(new_treasury.clone()),
+            restake_commission: new_team_commission,
+            transfer_commission: new_transfer_commission,
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(new_unbonding_period),
         }
@@ -101,14 +130,15 @@ fn proper_update() {
 
     let new_owner = "new_owner".to_owned();
     suite
-        .update_config(owner.as_str(), new_owner.clone(), None, None, None)
+        .update_config(owner.as_str(), new_owner.clone(), None, None, None, None)
         .unwrap();
     assert_eq!(
         suite.query_config().unwrap(),
         Config {
             owner: Addr::unchecked(new_owner),
             treasury: Addr::unchecked(new_treasury),
-            team_commission: new_team_commission,
+            restake_commission: new_team_commission,
+            transfer_commission: new_transfer_commission,
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(new_unbonding_period),
         }
@@ -116,7 +146,7 @@ fn proper_update() {
 
     // confirm that now updating with old owner results in error
     let err = suite
-        .update_config(owner.as_str(), None, None, None, None)
+        .update_config(owner.as_str(), None, None, None, None, None)
         .unwrap_err();
     assert_eq!(ContractError::Unauthorized {}, err.downcast().unwrap());
 }

--- a/contracts/interstake-yield-generator/src/multitest/config.rs
+++ b/contracts/interstake-yield-generator/src/multitest/config.rs
@@ -71,7 +71,7 @@ fn proper_update() {
 
     let new_unbonding_period = 300_000_000u64;
     suite
-        .update_config(owner.as_str(), None, None, None, None, new_unbonding_period)
+        .update_config(owner.as_str(), None, None, None, new_unbonding_period)
         .unwrap();
     assert_eq!(
         suite.query_config().unwrap(),

--- a/contracts/interstake-yield-generator/src/multitest/config.rs
+++ b/contracts/interstake-yield-generator/src/multitest/config.rs
@@ -81,7 +81,7 @@ fn proper_update() {
         suite.query_config().unwrap(),
         Config {
             owner: Addr::unchecked(new_owner),
-            team_commision: new_team_commision,
+            team_commission: new_team_commission,
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(new_unbonding_period),
         }

--- a/contracts/interstake-yield-generator/src/multitest/config.rs
+++ b/contracts/interstake-yield-generator/src/multitest/config.rs
@@ -26,7 +26,7 @@ fn proper_update() {
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
-            team_commision: Decimal::zero(),
+            team_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
         }
@@ -39,21 +39,21 @@ fn proper_update() {
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
-            team_commision: Decimal::zero(),
+            team_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
         }
     );
 
-    let new_team_commision = Decimal::percent(5);
+    let new_team_commission = Decimal::percent(5);
     suite
-        .update_config(owner.as_str(), None, new_team_commision, None)
+        .update_config(owner.as_str(), None, new_team_commission, None)
         .unwrap();
     assert_eq!(
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
-            team_commision: new_team_commision,
+            team_commission: new_team_commission,
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
         }
@@ -67,7 +67,7 @@ fn proper_update() {
         suite.query_config().unwrap(),
         Config {
             owner: owner.clone(),
-            team_commision: new_team_commision,
+            team_commission: new_team_commission,
             denom: "ujuno".to_owned(),
             unbonding_period: Timestamp::from_seconds(new_unbonding_period),
         }

--- a/contracts/interstake-yield-generator/src/multitest/delegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/delegate.rs
@@ -46,7 +46,7 @@ fn one_user(i: u32) {
     let reward_amount = suite.query_reward().unwrap().amount;
     let new_delegated = delegated + reward_amount;
 
-    // Default validator commision is 5%, APR is 80%
+    // Default validator commission is 5%, APR is 80%
     // 100_000_000 * 0.95 * 0.8 * (1/365) = 208_218.72
     assert_approx_eq!(reward_amount.u128(), 208_219u128, "0.00001");
     suite.restake(owner.as_str()).unwrap();

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -314,7 +314,7 @@ impl Suite {
         &mut self,
         sender: &str,
         addr: &str,
-        expires: Option<u64>,
+        expires: u64,
     ) -> AnyResult<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(sender),

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -126,7 +126,7 @@ impl SuiteBuilder {
                 &InstantiateMsg {
                     owner: self.owner.clone(),
                     staking_addr: VALIDATOR_1.to_owned(),
-                    team_commision: self.team_commision,
+                    team_commission: self.team_commission,
                     denom: self.denom,
                     unbonding_period: Some(TWENTY_EIGHT_DAYS),
                 },
@@ -203,7 +203,7 @@ impl Suite {
             self.contract.clone(),
             &ExecuteMsg::UpdateConfig {
                 owner: owner.into(),
-                team_commision: team_commision.into(),
+                team_commission: team_commission.into(),
                 unbonding_period: unbonding_period.into(),
             },
             &[],

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -34,7 +34,7 @@ where
 #[derive(Debug)]
 pub struct SuiteBuilder {
     pub owner: String,
-    pub team_commision: Decimal,
+    pub team_commission: Decimal,
     pub validator_commission: Decimal,
     pub funds: Vec<(Addr, Vec<Coin>)>,
     pub denom: String,
@@ -47,7 +47,7 @@ impl SuiteBuilder {
     pub fn new() -> Self {
         Self {
             owner: "owner".to_owned(),
-            team_commision: Decimal::zero(),
+            team_commission: Decimal::zero(),
             validator_commission: Decimal::percent(5),
             funds: vec![],
             denom: "ujuno".to_owned(),
@@ -195,7 +195,7 @@ impl Suite {
         &mut self,
         sender: &str,
         owner: impl Into<Option<String>>,
-        team_commision: impl Into<Option<Decimal>>,
+        team_commission: impl Into<Option<Decimal>>,
         unbonding_period: impl Into<Option<u64>>,
     ) -> AnyResult<AppResponse> {
         self.app.execute_contract(

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -72,7 +72,7 @@ impl SuiteBuilder {
         self
     }
 
-    pub fn with_team_commission(mut self, commission: Decimal) -> Self {
+    pub fn with_restake_commission(mut self, commission: Decimal) -> Self {
         self.restake_commission = commission;
         self
     }
@@ -296,6 +296,7 @@ impl Suite {
         sender: &str,
         recipient: &str,
         amount: Uint128,
+        commission_address: Option<String>,
     ) -> AnyResult<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(sender),
@@ -303,6 +304,7 @@ impl Suite {
             &ExecuteMsg::Transfer {
                 recipient: recipient.into(),
                 amount,
+                commission_address,
             },
             &[],
         )

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -69,6 +69,11 @@ impl SuiteBuilder {
         self
     }
 
+    pub fn with_team_commission(mut self, commission: Decimal) -> Self {
+        self.team_commission = commission;
+        self
+    }
+
     #[track_caller]
     pub fn build(self) -> Suite {
         let owner = Addr::unchecked(self.owner.clone());

--- a/contracts/interstake-yield-generator/src/multitest/transfer.rs
+++ b/contracts/interstake-yield-generator/src/multitest/transfer.rs
@@ -1,10 +1,11 @@
 use super::suite::SuiteBuilder;
 
-use cosmwasm_std::{coin, coins, Uint128};
+use cosmwasm_std::{coin, coins, Decimal, Uint128};
 
 use crate::{
     msg::{DelegateResponse, TotalDelegatedResponse},
     multitest::suite::validator_list,
+    state::Config,
 };
 use test_case::test_case;
 
@@ -66,6 +67,72 @@ fn delegate_and_transfer(i: u32) {
         suite.query_total_delegated().unwrap(),
         TotalDelegatedResponse {
             amount: coin(50_003_012u128, "ujuno")
+        }
+    );
+}
+
+#[test]
+fn transfer_with_commission() {
+    let user1 = ("user1", 50_000_000u128);
+    let user2 = "user2";
+    let mut suite = SuiteBuilder::new()
+        .with_funds(user1.0, &coins(user1.1, "ujuno"))
+        .with_team_commission(Decimal::percent(10))
+        .build();
+
+    let config: Config = suite.query_config().unwrap();
+    assert_eq!(config.team_commission, Decimal::percent(10));
+
+    suite.delegate(user1.0, coin(user1.1, "ujuno")).unwrap();
+
+    assert_eq!(
+        suite.query_delegated(user1.0).unwrap(),
+        DelegateResponse {
+            start_height: 12345,
+            total_staked: user1.1.into(),
+            total_earnings: Uint128::zero(),
+        }
+    );
+    assert_eq!(
+        suite.query_total_delegated().unwrap(),
+        TotalDelegatedResponse {
+            amount: coin(user1.1, "ujuno")
+        }
+    );
+    suite.advance_height(500);
+    suite.restake(suite.owner().as_str()).unwrap();
+
+    suite
+        .transfer(user1.0, user2, Uint128::new(30_000_000u128))
+        .unwrap();
+    assert_eq!(
+        suite.query_delegated(user1.0).unwrap(),
+        DelegateResponse {
+            start_height: 12345,
+            total_staked: Uint128::new(20_002_711u128),
+            total_earnings: Uint128::new(2_711u128),
+        }
+    );
+    assert_eq!(
+        suite.query_delegated(user2).unwrap(),
+        DelegateResponse {
+            start_height: 12345 + 500,
+            total_staked: Uint128::new(30_000_000u128 - 3_000_000u128),
+            total_earnings: Uint128::zero(),
+        }
+    );
+    assert_eq!(
+        suite.query_delegated(suite.treasury()).unwrap(),
+        DelegateResponse {
+            start_height: 12345 + 500,
+            total_staked: Uint128::new(3_000_000u128),
+            total_earnings: Uint128::zero(),
+        }
+    );
+    assert_eq!(
+        suite.query_total_delegated().unwrap(),
+        TotalDelegatedResponse {
+            amount: coin(50_002_711u128, "ujuno")
         }
     );
 }

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -8,6 +8,7 @@ use cw_storage_plus::{Item, Map};
 #[serde(rename_all = "snake_case")]
 pub struct Config {
     pub owner: Addr,
+    pub treasury: Addr,
     pub team_commision: Decimal,
     pub denom: String,
     pub unbonding_period: Timestamp,

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -9,7 +9,7 @@ use cw_storage_plus::{Item, Map};
 pub struct Config {
     pub owner: Addr,
     pub treasury: Addr,
-    pub team_commision: Decimal,
+    pub team_commission: Decimal,
     pub denom: String,
     pub unbonding_period: Timestamp,
 }

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -1,3 +1,4 @@
+use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +10,8 @@ use cw_storage_plus::{Item, Map};
 pub struct Config {
     pub owner: Addr,
     pub treasury: Addr,
-    pub team_commission: Decimal,
+    pub restake_commission: Decimal,
+    pub transfer_commission: Decimal,
     pub denom: String,
     pub unbonding_period: Timestamp,
 }
@@ -61,3 +63,4 @@ pub const LAST_PAYMENT_BLOCK: Item<u64> = Item::new("last_payment_block");
 pub const STAKE_DETAILS: Map<&Addr, StakeDetails> = Map::new("stake_details");
 pub const UNBONDING_CLAIMS: Map<&Addr, Vec<ClaimDetails>> = Map::new("unbonding_claims");
 pub const VALIDATOR_LIST: Map<String, Decimal> = Map::new("validator_list");
+pub const ALLOWED_ADDRESSES: Map<&Addr, Expiration> = Map::new("allowed_addresses");


### PR DESCRIPTION
This pr includes the following additions to the code:
1. treasury account is added to config and rewards are now sent to that account(Fixes #13 )
2. optional commission_address is added to transfer function (Fixes #12 )
