### PR TITLE
Fix/max entries

### DIFF
--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -262,12 +262,10 @@ mod execute {
 
     pub fn queue_undelegate(
         deps: DepsMut,
-        env: Env,
+        _env: Env,
         info: MessageInfo,
         amount: Coin,
     ) -> Result<Response, ContractError> {
-        let config = CONFIG.load(deps.storage)?;
-
         let mut stake_details = STAKE_DETAILS
             .load(deps.storage, &info.sender)
             .map_err(|_| ContractError::DelegationNotFound {})?;
@@ -308,7 +306,7 @@ mod execute {
 
     pub fn reconcile(deps: DepsMut, env: Env, _info: MessageInfo) -> Result<Response, ContractError> {
         UNBOND_INFO.update(deps.storage, |info: UnbondInfo| -> Result<_, ContractError> {
-            Ok(info.unbond_now(env.block.time)?)
+            info.unbond_now(env.block.time)
         })?;
 
         let config = CONFIG.load(deps.storage)?;

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -1194,7 +1194,7 @@ pub mod utils {
                 err as ContractError,
                 ContractError::UnbondingCooldownNotExpired {
                     min_cooldown: Duration::Time(1),
-                    latest_unbonding: latest_unbonding
+                    latest_unbonding
                 }
             );
 

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -307,6 +307,9 @@ mod execute {
     }
 
     pub fn reconcile(deps: DepsMut, env: Env, _info: MessageInfo) -> Result<Response, ContractError> {
+        UNBOND_INFO.update(deps.storage, |info: UnbondInfo| -> Result<_, ContractError> {
+            Ok(info.unbond_now(env.block.time)?)
+        })?;
 
         let config = CONFIG.load(deps.storage)?;
 

--- a/contracts/interstake-yield-generator/src/contract.rs
+++ b/contracts/interstake-yield-generator/src/contract.rs
@@ -385,7 +385,7 @@ mod execute {
                 }
             });
 
-            Ok(unexpired_claims.clone())
+            Ok(unexpired_claims)
         })?;
 
         let mut response = Response::new()
@@ -404,7 +404,7 @@ mod execute {
         if !claim_amount.is_zero() {
             let msg = BankMsg::Send {
                 to_address: info.sender.to_string(),
-                amount: vec![coin(claim_amount.u128(), &config.denom)],
+                amount: vec![coin(claim_amount.u128(), config.denom)],
             };
             response = response.add_message(msg);
         }

--- a/contracts/interstake-yield-generator/src/error.rs
+++ b/contracts/interstake-yield-generator/src/error.rs
@@ -1,3 +1,4 @@
+use cw_utils::Expiration;
 use thiserror::Error;
 
 use cosmwasm_std::{StdError, Uint128};
@@ -48,8 +49,11 @@ pub enum ContractError {
     #[error("Commission address may not be the same as the recipient")]
     CommissionAddressSameAsRecipient {},
 
-    #[error("Unbonding called too soon after last unbonding")]
-    UnbondingTooSoon {},
+    #[error("Minimum cooldown {min_cooldown:?} has not passed since the the latest unbonding {latest_unbonding:?}")]
+    UnbondingCooldownNotExpired {
+        min_cooldown: cw_utils::Duration,
+        latest_unbonding: Expiration,
+    },
 
     #[error("Semver parsing error: {0}")]
     SemVer(String),

--- a/contracts/interstake-yield-generator/src/error.rs
+++ b/contracts/interstake-yield-generator/src/error.rs
@@ -48,6 +48,9 @@ pub enum ContractError {
     #[error("Commission address may not be the same as the recipient")]
     CommissionAddressSameAsRecipient {},
 
+    #[error("Unbonding called too soon after last unbonding")]
+    UnbondingTooSoon {},
+
     #[error("Semver parsing error: {0}")]
     SemVer(String),
 }

--- a/contracts/interstake-yield-generator/src/migration.rs
+++ b/contracts/interstake-yield-generator/src/migration.rs
@@ -2,11 +2,11 @@ use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Decimal, DepsMut, Timestamp, Env};
+use cosmwasm_std::{Addr, Decimal, DepsMut, Env, Timestamp};
 
 use crate::error::ContractError;
 use crate::msg::MigrateMsg;
-use crate::state::{Config, CONFIG, VALIDATOR_LIST, UNBOND_INFO, UnbondInfo};
+use crate::state::{Config, UnbondInfo, CONFIG, UNBOND_INFO, VALIDATOR_LIST};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/interstake-yield-generator/src/migration.rs
+++ b/contracts/interstake-yield-generator/src/migration.rs
@@ -3,11 +3,11 @@ use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Decimal, DepsMut, Env, Timestamp};
+use cosmwasm_std::{Addr, Decimal, DepsMut, Env};
 
 use crate::error::ContractError;
 use crate::msg::MigrateMsg;
-use crate::state::{Config, CONFIG, VALIDATOR_LIST, LATEST_UNBONDING};
+use crate::state::{Config, CONFIG, LATEST_UNBONDING, VALIDATOR_LIST};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -27,9 +27,8 @@ pub fn migrate_config(
     let owner = deps.api.addr_validate(&msg.owner)?;
     let treasury = deps.api.addr_validate(&msg.treasury)?;
 
-
     let max_entries = msg.max_entries.unwrap_or(7);
-    let unbonding_period = msg.unbonding_period.unwrap_or(3600*24*28);
+    let unbonding_period = msg.unbonding_period.unwrap_or(3600 * 24 * 28);
     let min_unbonding_cooldown = Duration::Time(unbonding_period.saturating_div(max_entries));
 
     let new_config = Config {
@@ -39,11 +38,14 @@ pub fn migrate_config(
         transfer_commission: msg.transfer_commission,
         denom: msg.denom.clone(),
         unbonding_period: Duration::Time(unbonding_period),
-        min_unbonding_cooldown ,
+        min_unbonding_cooldown,
     };
 
     // sets the latest unbonding period to 4 days from now
-    LATEST_UNBONDING.save(deps.storage, &Expiration::AtTime(env.block.time.minus_seconds(3600*24*4)))?;
+    LATEST_UNBONDING.save(
+        deps.storage,
+        &Expiration::AtTime(env.block.time.minus_seconds(3600 * 24 * 4)),
+    )?;
 
     VALIDATOR_LIST.save(deps.storage, msg.staking_addr, &Decimal::one())?;
     CONFIG.save(deps.storage, &new_config)?;

--- a/contracts/interstake-yield-generator/src/msg.rs
+++ b/contracts/interstake-yield-generator/src/msg.rs
@@ -83,7 +83,7 @@ pub enum QueryMsg {
     Reward {},
     /// Returns the amount of tokens that are currently pending for claim
     #[returns(PendingClaimResponse)]
-    PendingClaim {sender: String},
+    PendingClaim { sender: String },
     /// Returns all current unbonding claims for sender
     #[returns(ClaimsResponse)]
     Claims { sender: String },

--- a/contracts/interstake-yield-generator/src/msg.rs
+++ b/contracts/interstake-yield-generator/src/msg.rs
@@ -20,6 +20,8 @@ pub struct InstantiateMsg {
     pub denom: String,
     /// Unbondig period in seconds. Default: 2_419_200 (28 days)
     pub unbonding_period: Option<u64>,
+    /// maxEntries in unbonding queue. Default: 7
+    pub max_entries: Option<u64>,
 }
 
 #[cw_serde]
@@ -51,7 +53,7 @@ pub enum ExecuteMsg {
         commission_address: Option<String>,
     },
     /// Start unbonding current batch
-    Reconcile {},
+    BatchUnbond {},
     /// Undelegates all tokens
     UndelegateAll {},
     /// adds (or updates) address to allowed list
@@ -79,6 +81,9 @@ pub enum QueryMsg {
     /// Current available reward to claim
     #[returns(RewardResponse)]
     Reward {},
+    /// Returns the amount of tokens that are currently pending for claim
+    #[returns(PendingClaimResponse)]
+    PendingClaim {sender: String},
     /// Returns all current unbonding claims for sender
     #[returns(ClaimsResponse)]
     Claims { sender: String },
@@ -113,6 +118,8 @@ pub struct MigrateMsg {
     pub denom: String,
     /// Unbondig period in seconds. Default: 2_419_200 (28 days)
     pub unbonding_period: Option<u64>,
+    /// maxEntries in unbonding queue. Default: 7
+    pub max_entries: Option<u64>,
 }
 
 #[cw_serde]
@@ -123,6 +130,11 @@ pub struct ConfigResponse {
 #[cw_serde]
 pub struct RewardResponse {
     pub rewards: Vec<Coin>,
+}
+
+#[cw_serde]
+pub struct PendingClaimResponse {
+    pub amount: Uint128,
 }
 
 #[cw_serde]

--- a/contracts/interstake-yield-generator/src/msg.rs
+++ b/contracts/interstake-yield-generator/src/msg.rs
@@ -50,6 +50,8 @@ pub enum ExecuteMsg {
         amount: Uint128,
         commission_address: Option<String>,
     },
+    /// Start unbonding current batch
+    Reconcile {},
     /// Undelegates all tokens
     UndelegateAll {},
     /// adds (or updates) address to allowed list

--- a/contracts/interstake-yield-generator/src/multitest/config.rs
+++ b/contracts/interstake-yield-generator/src/multitest/config.rs
@@ -1,6 +1,6 @@
 use super::suite::{SuiteBuilder, TWENTY_EIGHT_DAYS};
 
-use cosmwasm_std::{coin, Addr, Decimal, StakingMsg, Timestamp, Uint128};
+use cosmwasm_std::{coin, Addr, Decimal, StakingMsg, Uint128};
 use cw_utils::Duration;
 
 use crate::contract::utils::compute_redelegate_msgs;

--- a/contracts/interstake-yield-generator/src/multitest/config.rs
+++ b/contracts/interstake-yield-generator/src/multitest/config.rs
@@ -1,6 +1,7 @@
 use super::suite::{SuiteBuilder, TWENTY_EIGHT_DAYS};
 
 use cosmwasm_std::{coin, Addr, Decimal, StakingMsg, Timestamp, Uint128};
+use cw_utils::Duration;
 
 use crate::contract::utils::compute_redelegate_msgs;
 use crate::error::ContractError;
@@ -31,7 +32,8 @@ fn proper_update() {
             restake_commission: Decimal::zero(),
             transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
+            unbonding_period: Duration::Time(TWENTY_EIGHT_DAYS),
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 
@@ -46,7 +48,9 @@ fn proper_update() {
             restake_commission: Decimal::zero(),
             transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
+            unbonding_period: Duration::Time(TWENTY_EIGHT_DAYS),
+
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 
@@ -62,7 +66,8 @@ fn proper_update() {
             restake_commission: new_team_commission,
             transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(TWENTY_EIGHT_DAYS),
+            unbonding_period: Duration::Time(TWENTY_EIGHT_DAYS),
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 
@@ -78,7 +83,8 @@ fn proper_update() {
             restake_commission: new_team_commission,
             transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(new_unbonding_period),
+            unbonding_period: Duration::Time(new_unbonding_period),
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 
@@ -94,7 +100,8 @@ fn proper_update() {
             restake_commission: new_team_commission,
             transfer_commission: Decimal::zero(),
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(new_unbonding_period),
+            unbonding_period: Duration::Time(new_unbonding_period),
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 
@@ -117,7 +124,8 @@ fn proper_update() {
             restake_commission: new_team_commission,
             transfer_commission: new_transfer_commission,
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(new_unbonding_period),
+            unbonding_period: Duration::Time(new_unbonding_period),
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 
@@ -133,7 +141,8 @@ fn proper_update() {
             restake_commission: new_team_commission,
             transfer_commission: new_transfer_commission,
             denom: "ujuno".to_owned(),
-            unbonding_period: Timestamp::from_seconds(new_unbonding_period),
+            unbonding_period: Duration::Time(new_unbonding_period),
+            min_unbonding_cooldown: Duration::Time(TWENTY_EIGHT_DAYS / 7),
         }
     );
 

--- a/contracts/interstake-yield-generator/src/multitest/delegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/delegate.rs
@@ -573,7 +573,7 @@ fn redelegate_after_validator_list_update() {
         .unwrap();
 
     suite.undelegate("user", coin(1000u128, "ujuno")).unwrap();
-    suite.reconcile("user").unwrap();
+    suite.batch_unbond("user").unwrap();
     suite.advance_time(TWENTY_EIGHT_DAYS);
     suite.process_staking_queue().unwrap();
 

--- a/contracts/interstake-yield-generator/src/multitest/delegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/delegate.rs
@@ -573,6 +573,7 @@ fn redelegate_after_validator_list_update() {
         .unwrap();
 
     suite.undelegate("user", coin(1000u128, "ujuno")).unwrap();
+    suite.reconcile("user").unwrap();
     suite.advance_time(TWENTY_EIGHT_DAYS);
     suite.process_staking_queue().unwrap();
 

--- a/contracts/interstake-yield-generator/src/multitest/migrate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/migrate.rs
@@ -50,7 +50,7 @@ fn recently_failed_migration() {
                 transfer_commission,
                 denom: "ujuno".to_string(),
                 unbonding_period: None,
-                max_entries: Some(7)
+                max_entries: Some(7),
             },
         )
         .unwrap();

--- a/contracts/interstake-yield-generator/src/multitest/migrate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/migrate.rs
@@ -50,6 +50,7 @@ fn recently_failed_migration() {
                 transfer_commission,
                 denom: "ujuno".to_string(),
                 unbonding_period: None,
+                max_entries: Some(7)
             },
         )
         .unwrap();
@@ -73,6 +74,7 @@ fn recently_failed_migration() {
                 transfer_commission,
                 denom: "ujuno".to_string(),
                 unbonding_period: None,
+                max_entries: Some(7),
             },
         )
         .unwrap();

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -129,7 +129,7 @@ impl SuiteBuilder {
         let mut validators: Vec<Validator> = vec![];
         for number in 1..=self.number_of_validators {
             let validator = Validator {
-                address: format!("validator{}", number),
+                address: format!("validator{number}"),
                 commission: self.validator_commission,
                 max_commission: Decimal::percent(100),
                 max_change_rate: Decimal::percent(1),

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -25,6 +25,7 @@ use crate::msg::{
 use crate::state::{ClaimDetails, Config};
 
 pub const TWENTY_EIGHT_DAYS: u64 = 3600 * 24 * 28;
+pub const FOUR_DAYS: u64 = 3600 * 24 * 4;
 
 pub fn contract_yield_generator<C>() -> Box<dyn Contract<C>>
 where

--- a/contracts/interstake-yield-generator/src/multitest/suite.rs
+++ b/contracts/interstake-yield-generator/src/multitest/suite.rs
@@ -417,6 +417,15 @@ impl Suite {
         )
     }
 
+    pub fn reconcile(&mut self, sender: &str) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(sender),
+            self.contract.clone(),
+            &ExecuteMsg::Reconcile {},
+            &[],
+        )
+    }
+
     pub fn query_config(&self) -> AnyResult<Config> {
         let response: ConfigResponse = self
             .app

--- a/contracts/interstake-yield-generator/src/multitest/undelegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/undelegate.rs
@@ -1,6 +1,6 @@
 use super::suite::{SuiteBuilder, TWENTY_EIGHT_DAYS};
 
-use crate::error::ContractError;
+use crate::{error::ContractError, multitest::suite::FOUR_DAYS};
 use crate::msg::DelegateResponse;
 use crate::multitest::suite::validator_list;
 use crate::state::ClaimDetails;
@@ -72,6 +72,11 @@ fn create_basic_claim(i: u32) {
         ContractError::UnbondingTooSoon {  },
         err.downcast().unwrap()
     );
+
+
+    suite.advance_time(FOUR_DAYS);
+    suite.reconcile(user).unwrap();
+
 }
 
 #[test_case(1; "single_validator")]

--- a/contracts/interstake-yield-generator/src/multitest/undelegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/undelegate.rs
@@ -248,9 +248,7 @@ fn unexpired_claims_arent_removed() {
 fn undelegate_multiple_users_reconcile(i: u32, n_users: u32) {
     let validators = validator_list(i);
 
-    let users = (0..n_users)
-        .map(|i| format!("user{i}"))
-        .collect::<Vec<_>>();
+    let users = (0..n_users).map(|i| format!("user{i}")).collect::<Vec<_>>();
 
     let all_funds = users
         .iter()
@@ -297,9 +295,7 @@ fn undelegate_multiple_users_reconcile(i: u32, n_users: u32) {
 fn undelegate_all(i: u32, n_users: u32) {
     let validators = validator_list(i);
 
-    let users = (0..n_users)
-        .map(|i| format!("user{i}"))
-        .collect::<Vec<_>>();
+    let users = (0..n_users).map(|i| format!("user{i}")).collect::<Vec<_>>();
 
     let all_funds = users
         .iter()

--- a/contracts/interstake-yield-generator/src/multitest/undelegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/undelegate.rs
@@ -73,7 +73,6 @@ fn create_basic_claim(i: u32) {
         err.downcast().unwrap()
     );
 
-
     suite.advance_time(FOUR_DAYS);
     suite.reconcile(user).unwrap();
 

--- a/contracts/interstake-yield-generator/src/multitest/undelegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/undelegate.rs
@@ -227,7 +227,7 @@ fn unexpired_claims_arent_removed() {
     suite.claim(user).unwrap();
     assert_eq!(
         suite.query_claims(user).unwrap(),
-        vec![ClaimDetails {amount:coin(700,"ujuno"), release_timestamp: Expiration::AtTime(current_time.plus_seconds(TWENTY_EIGHT_DAYS))}]
+        vec![ClaimDetails {amount:coin(700,"ujuno"), release_timestamp: Expiration::AtTime(current_time.plus_seconds(TWENTY_EIGHT_DAYS/2))}]
     );
 }
 

--- a/contracts/interstake-yield-generator/src/multitest/undelegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/undelegate.rs
@@ -1,9 +1,9 @@
 use super::suite::{SuiteBuilder, TWENTY_EIGHT_DAYS};
 
-use crate::{error::ContractError, multitest::suite::FOUR_DAYS};
 use crate::msg::DelegateResponse;
 use crate::multitest::suite::validator_list;
 use crate::state::ClaimDetails;
+use crate::{error::ContractError, multitest::suite::FOUR_DAYS};
 use cosmwasm_std::{coin, coins, Addr, Uint128};
 use test_case::test_case;
 
@@ -54,7 +54,8 @@ fn create_basic_claim(i: u32) {
         suite.query_claims(user).unwrap(),
         vec![ClaimDetails {
             amount: coin(100, "ujuno"),
-            release_timestamp: Some(current_time.plus_seconds(TWENTY_EIGHT_DAYS))}]
+            release_timestamp: Some(current_time.plus_seconds(TWENTY_EIGHT_DAYS))
+        }]
     );
 
     assert_eq!(
@@ -66,16 +67,11 @@ fn create_basic_claim(i: u32) {
         }
     );
 
-
     let err = suite.reconcile(user).unwrap_err();
-    assert_eq!(
-        ContractError::UnbondingTooSoon {  },
-        err.downcast().unwrap()
-    );
+    assert_eq!(ContractError::UnbondingTooSoon {}, err.downcast().unwrap());
 
     suite.advance_time(FOUR_DAYS);
     suite.reconcile(user).unwrap();
-
 }
 
 #[test_case(1; "single_validator")]

--- a/contracts/interstake-yield-generator/src/multitest/undelegate.rs
+++ b/contracts/interstake-yield-generator/src/multitest/undelegate.rs
@@ -249,7 +249,7 @@ fn undelegate_multiple_users_reconcile(i: u32, n_users: u32) {
     let validators = validator_list(i);
 
     let users = (0..n_users)
-        .map(|i| format!("user{}", i))
+        .map(|i| format!("user{i}"))
         .collect::<Vec<_>>();
 
     let all_funds = users
@@ -298,7 +298,7 @@ fn undelegate_all(i: u32, n_users: u32) {
     let validators = validator_list(i);
 
     let users = (0..n_users)
-        .map(|i| format!("user{}", i))
+        .map(|i| format!("user{i}"))
         .collect::<Vec<_>>();
 
     let all_funds = users
@@ -329,7 +329,7 @@ fn undelegate_all(i: u32, n_users: u32) {
     assert_eq!(ContractError::Unauthorized {}, res.downcast().unwrap());
 
     let res = suite.undelegate_all(suite.owner().as_str());
-    assert!(res.is_ok(), "undelegate_all by owner failed: {:?}", res);
+    assert!(res.is_ok(), "undelegate_all by owner failed: {res:?}");
 
     // see if all the delegations are actually gone
     let stake = suite.query_all_delegations().unwrap();
@@ -353,7 +353,7 @@ fn undelegate_all(i: u32, n_users: u32) {
 
     for user in &users {
         if let Err(err) = suite.claim(user.as_str()) {
-            panic!("claim failed: {:?}", err);
+            panic!("claim failed: {err:?}");
         }
     }
 

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -3,7 +3,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Coin, Decimal, StdResult, Storage, Timestamp, Uint128};
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::{Item, Map, IndexedMap, MultiIndex, IndexList, Index};
+
+use crate::ContractError;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -47,14 +49,46 @@ impl StakeDetails {
         Ok(())
     }
 }
-
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ClaimDetails {
     pub release_timestamp: Timestamp,
     pub amount: Coin,
+    pub processed: bool,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct UnbondInfo {
+    pub latest: Timestamp,
 }
 
+pub const FOUR_DAYS: u64 = 4*60*60*24;
+
+impl UnbondInfo {
+    fn unbond_now(&mut self, now:Timestamp) -> Result<(), ContractError> {
+        if self.latest.plus_seconds(FOUR_DAYS) < now {
+            self.latest = now;
+            Ok(())
+        } else {
+            Err(ContractError::UnbondingTooSoon {  })
+        }
+    }
+
+    pub fn now(now:Timestamp) -> Self {
+        UnbondInfo {
+            latest: now,
+        }
+    }
+
+    pub fn new(now:Timestamp) -> Self {
+        UnbondInfo {
+            latest: now.minus_seconds(FOUR_DAYS),
+        }
+    }
+}
+
+
+pub const UNBOND_INFO : Item<UnbondInfo> = Item::new("unbond_info");
 pub const CONFIG: Item<Config> = Item::new("config");
 // Total amount of staked tokens
 // TODO: Replace with Vec<Coin>

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -64,10 +64,9 @@ pub struct UnbondInfo {
 pub const FOUR_DAYS: u64 = 4*60*60*24;
 
 impl UnbondInfo {
-    fn unbond_now(&mut self, now:Timestamp) -> Result<(), ContractError> {
-        if self.latest.plus_seconds(FOUR_DAYS) < now {
-            self.latest = now;
-            Ok(())
+    pub fn unbond_now(self, now:Timestamp) -> Result<UnbondInfo, ContractError> {
+        if self.latest.plus_seconds(FOUR_DAYS) <= now {
+            Ok(UnbondInfo { latest: now })
         } else {
             Err(ContractError::UnbondingTooSoon {  })
         }

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -52,9 +52,8 @@ impl StakeDetails {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ClaimDetails {
-    pub release_timestamp: Timestamp,
+    pub release_timestamp: Option<Timestamp>,
     pub amount: Coin,
-    pub processed: bool,
 }
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -61,32 +61,29 @@ pub struct UnbondInfo {
     pub latest: Timestamp,
 }
 
-pub const FOUR_DAYS: u64 = 4*60*60*24;
+pub const FOUR_DAYS: u64 = 4 * 60 * 60 * 24;
 
 impl UnbondInfo {
-    pub fn unbond_now(self, now:Timestamp) -> Result<UnbondInfo, ContractError> {
+    pub fn unbond_now(self, now: Timestamp) -> Result<UnbondInfo, ContractError> {
         if self.latest.plus_seconds(FOUR_DAYS) <= now {
             Ok(UnbondInfo { latest: now })
         } else {
-            Err(ContractError::UnbondingTooSoon {  })
+            Err(ContractError::UnbondingTooSoon {})
         }
     }
 
-    pub fn now(now:Timestamp) -> Self {
-        UnbondInfo {
-            latest: now,
-        }
+    pub fn now(now: Timestamp) -> Self {
+        UnbondInfo { latest: now }
     }
 
-    pub fn new(now:Timestamp) -> Self {
+    pub fn new(now: Timestamp) -> Self {
         UnbondInfo {
             latest: now.minus_seconds(FOUR_DAYS),
         }
     }
 }
 
-
-pub const UNBOND_INFO : Item<UnbondInfo> = Item::new("unbond_info");
+pub const UNBOND_INFO: Item<UnbondInfo> = Item::new("unbond_info");
 pub const CONFIG: Item<Config> = Item::new("config");
 // Total amount of staked tokens
 // TODO: Replace with Vec<Coin>

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Coin, Decimal, StdResult, Storage, Timestamp, Uint128};
-use cw_storage_plus::{Item, Map, IndexedMap, MultiIndex, IndexList, Index};
+use cw_storage_plus::{Item, Map};
 
 use crate::ContractError;
 

--- a/contracts/interstake-yield-generator/src/state.rs
+++ b/contracts/interstake-yield-generator/src/state.rs
@@ -1,11 +1,9 @@
-use cw_utils::{Expiration, Duration};
+use cw_utils::{Duration, Expiration};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Coin, Decimal, StdResult, Storage, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, Decimal, StdResult, Storage, Uint128};
 use cw_storage_plus::{Item, Map};
-
-use crate::ContractError;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Fixes #22 

This is a really hacky but functional solution. 
I made adjusted all the tests so they work with reconcile() (the function that wil undelegate the unconfirmed claims,

A ClaimDetail is unconfirmed if the timestamp is set to None.

Please if you have the time @ueco-jb Add some tests, merge it and preferably also create a new release.